### PR TITLE
Prevent callback being called twice when it throws an error

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,13 +26,19 @@ function mothership(start, ismothership, cb) {
       if (err) return cb(err);
       if (!packageDir) return cb();
 
-      var pack;
+      var pack, result;
       try {
         pack = require(path.join(packageDir, 'package.json'));
-        if (ismothership(pack)) return cb(null, { path: path.join(packageDir, 'package.json'), pack: pack });
-        findShip(path.resolve(root, '..'));
+        if (ismothership(pack)) {
+          result = { path: path.join(packageDir, 'package.json'), pack: pack };
+        } else {
+          findShip(path.resolve(root, '..'));
+        }
       } catch (e) {
-        cb(e);
+        return cb(e);
+      }
+      if (result) {
+        return cb(null, result);
       }
     });
 


### PR DESCRIPTION
When the callback threw an error it got caught in the catch block, which
called the callback again but now with the error. This resulted in the
callback being called twice.

By extracting the call to the callback to outside the try-catch block this is
prevented
